### PR TITLE
remove plugin URI; fix rotate icons

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -3,7 +3,6 @@
 Plugin Name: EasyRotate
 Version: 0.8
 Description: This plugin allows easy rotation of pictures from the picture page.
-Plugin URI: http://piwigo.org/ext/extension_view.php?eid=847
 Author: ramack
 Author URI: http://www.raphael-mack.de
 

--- a/template/rotate_buttons.tpl
+++ b/template/rotate_buttons.tpl
@@ -13,7 +13,7 @@ $(document).ready(function() {
 
 {if ROTATE_BOOTSTRAP == 1}
   <li class="nav-item">
-      <a href="javascript:void(0)" onclick="onEasyRotateClicked(90)" title="{'Rotate counterclockwise'|translate}" class="pwg-state-default pwg-button nav-link" rel="nofollow">
+      <a href="javascript:void(0)" onclick="onEasyRotateClicked(90)" title="{'Rotate counterclockwise'|translate}" class="pwg-state-default pwg-button nav-link" rel="nofollow">foo
         <i class="fas fa-undo fa-fw" aria-hidden="true"></i>
         <span class="pwg-button-text">{'EasyRotate'|translate}</span>
       </a>
@@ -25,11 +25,11 @@ $(document).ready(function() {
       </a>
   </li>
 {elseif ROTATE_BOOTSTRAP == 0}
-  <a href="javascript:void(0)" onclick="onEasyRotateClicked(90)" title="{'Rotate counterclockwise'|translate}" class="pwg-state-default pwg-button" rel="nofollow">
+  <a href="javascript:void(0)" onclick="onEasyRotateClicked(90)" title="{'Rotate counterclockwise'|translate}" class="pwg-state-default pwg-button" rel="nofollow"><img src="{$EASYROTATE_PATH}template/rotate_ccw.png" style="background-color:black;" />
     <span class="pwg-icon easyrotate-ccw-button"> </span>
     <span class="pwg-button-text">{'EasyRotate'|translate}</span>
   </a>
-  <a href="javascript:void(0)" onclick="onEasyRotateClicked(270)" title="{'Rotate clockwise'|translate}" class="pwg-state-default pwg-button" rel="nofollow">
+  <a href="javascript:void(0)" onclick="onEasyRotateClicked(270)" title="{'Rotate clockwise'|translate}" class="pwg-state-default pwg-button" rel="nofollow"><img src="{$EASYROTATE_PATH}template/rotate_cw.png" style="background-color:black;" />
     <span class="pwg-icon easyrotate-cw-button"> </span>
     <span class="pwg-button-text">{'EasyRotate'|translate}</span>
   </a>


### PR DESCRIPTION
This pull request does two things: 

1. It remove the upstream "URI" of the plugin that prevents it from passing a check that it is valid to use. 
2. It adds the rotate icons to the button template, so folks can click them.